### PR TITLE
Changes to run under Rakudo 2014.12

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,6 @@
 {
     "name" : "MongoDB",
-    "version" : "0.3",
+    "version" : "0.4",
     "description" : "MongoDB driver",
     "author" : "Pawel Pabian",
     "authority" : "bbkr",

--- a/META.info
+++ b/META.info
@@ -1,8 +1,8 @@
 {
     "name" : "MongoDB",
-    "version" : "0.4",
+    "version" : "0.5",
     "description" : "MongoDB driver",
-    "author" : "Pawel Pabian",
+    "author" : "Pawel Pabian, changes by Marcel Timmerman",
     "authority" : "bbkr",
     "depends" : [ "BSON" ],
     "source-url" : "git://github.com/bbkr/mongo-perl6-driver.git"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ removed with release v2015.7! Remove the curly brackets or replace with %(...).
         'IRC' => False,
     );
 
-    $collection.insert( %document1, %document2 );
+    # Arguments get flattened out so the test will go wrong in .insert()
+    # Use {} round the documents to keep them apart
+    #
+    $collection.insert( {%document1}, {%document2} );
 ```
 
 Flags:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Let's see what it can do...
 
 ### Insert documents into collection
 
+The declaration 'my %document1 = {...};' is deprecated since v2014.7 and will be
+removed with release v2015.7! Remove the curly brackets or replace with %(...).
+
 ```perl
-    my %document1 = {
+    my %document1 = %(
         'name'      => 'Paweł Pabian',
         'nick'      => 'bbkr',
         'versions'  => [ 5, 6 ],
@@ -33,14 +36,14 @@ Let's see what it can do...
             'Integer::Tiny' => 'http://search.cpan.org/perldoc?Integer%3A%3ATiny',
         },
         'IRC' => True,
-    };
+    );
     
-    my %document2 = {
+    my %document2 = %(
         'name' => 'Andrzej Cholewiusz',
         'nick' => 'andee',
         'versions' => [ 5 ],
         'IRC' => False,
-    };
+    );
 
     $collection.insert( %document1, %document2 );
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ removed with release v2015.7! Remove the curly brackets or replace with %(...).
     # Use {} round the documents to keep them apart
     #
     $collection.insert( {%document1}, {%document2} );
+    
+    # Also possible
+    my %document3 =
+      'name' => 'Pietje Bell',
+      'nick' => 'pb',
+      'versions' => [ 4 ],
+      'IRC' => False,
+      ;
+
+    $collection.insert( $%document3,
+                        $%( 'name' => 'Jan Klaassen',
+                            'nick' => 'jk',
+                            'versions' => [ 3, 4 ],
+                            'IRC' => False,
+                          )
+                      );
 ```
 
 Flags:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Leaf](http://modules.perl6.org/logos/MongoDB.png)
 
+Compatible with Perl 6 [Rakudo Star](http://rakudo.org/) ~~2012.01+~~ 2014.12.1.
+
 ## SYNOPSIS
 
 Let's see what it can do...
@@ -160,6 +162,7 @@ List of things you may expect in nearest future.
 
 ## CHANGELOG
 
+* 0.5 - 2015.01.10 compatibility fixes for Rakudo Star 2014.12.1
 * 0.4 - compatibility fixes for Rakudo Star 2012.02
 * 0.3 - basic flags added to methods (upsert, multi_update, single_remove,...), kill support for cursor
 * 0.2- adapted to Rakudo NOM 2011.09+.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Requires [BSON 0.2+](https://github.com/bbkr/BSON).
 
-Compatible with Perl 6 [Rakudo Star](http://rakudo.org/) 2012.01+.
+Compatible with Perl 6 [Rakudo Star](http://rakudo.org/) ~~2012.01+~~ 2014.12.1.
 
 ## SYNOPSIS
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 Compatible with Perl 6 [Rakudo Star](http://rakudo.org/) ~~2012.01+~~ 2014.12.1.
 
+## ADOPT ME
+
+I am friendly module that looks for a new home along with my best friend [BSON](https://github.com/bbkr/BSON).
+
+My owner played with me for the last time in early 2012 and a lot has changed since then - both in Rakudo and Mongo spec itself.
+
+If you want to take care of me please leave comment under last commit.
+
+![Paw prints](http://emoji.fileformat.info/gemoji/feet.png)
+
 ## SYNOPSIS
 
 Let's see what it can do...
@@ -162,7 +172,6 @@ List of things you may expect in nearest future.
 
 ## CHANGELOG
 
-* 0.5 - 2015.01.10 compatibility fixes for Rakudo Star 2014.12.1
 * 0.4 - compatibility fixes for Rakudo Star 2012.02
 * 0.3 - basic flags added to methods (upsert, multi_update, single_remove,...), kill support for cursor
 * 0.2- adapted to Rakudo NOM 2011.09+.

--- a/lib/MongoDB/Connection.pm
+++ b/lib/MongoDB/Connection.pm
@@ -20,7 +20,7 @@ method database ( Str $name ) {
 
 method send ( Buf $b, Bool $has_response ) {
 
-    $!sock.send( [~]( $b.list>>.chr ) );
+    $!sock.write( $b );
 
     # some calls do not expect response
     return unless $has_response;


### PR DESCRIPTION
The important change lies in **class MongoDB::Connection** where the call to IO::Socket::INET **send()** is changed to **write()**. The **send()** needed a string for which the buffer **$b** must be decoded. This will corrupt the mongodb opcodes. This could be noticed by using wireshark. **Write()** however can process the buffer directly making it faster too.

The rest of the changes are in **META.info** to change the version and the **README.md** to modify the examples and changelog

